### PR TITLE
Simple example for posting a status update

### DIFF
--- a/examples/status_bot.php
+++ b/examples/status_bot.php
@@ -1,0 +1,22 @@
+<?php
+
+include_once 'Mastodon.php';
+
+$token = ''; // Token of your Mastodon bot account
+$baseURL = 'https://botsin.space'; // URL of your instance (Do not include '/' at the end.)
+$privacy = 'private'; // "Direct" means sending message as a private message. The four tiers of privacy for toots are public , unlisted, private, and direct
+$language = 'en'; // en for English, zh for Chinese, de for German etc.
+$statusText = 'This is a status';
+
+$statusData = array(
+'status'      => $statusText,
+'privacy'     => $privacy,
+'language'    => $language
+);
+
+$mastodon = new MastodonAPI($token, $baseURL);
+$result = $mastodon->postStatus($statusData);
+
+// Activate the next line if you want to print the result of the query
+//var_dump($result);
+?>


### PR DESCRIPTION
Created a new example script to show how to simply post a plain text status update to a Mastodon account.