### PR TITLE
Fixed definition of $header

### DIFF
--- a/Mastodon.php
+++ b/Mastodon.php
@@ -25,7 +25,7 @@
         {
             $headers = [
                 'Authorization: Bearer '.$this->token,
-                'Content-Type: multipart/form-data',
+                'Content-Type: multipart/form-data'
             ];
 
             $ch = curl_init();


### PR DESCRIPTION
Removed the "," at the end of the $header-definition, since this made the script stop working